### PR TITLE
[PR-6] Loot tables

### DIFF
--- a/src/main/java/com/nowa/block/ModBlocks.java
+++ b/src/main/java/com/nowa/block/ModBlocks.java
@@ -10,6 +10,7 @@ import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.intprovider.UniformIntProvider;
 
 import static com.nowa.TemplateMod.LOGGER;
 import static com.nowa.TemplateMod.MOD_ID;
@@ -17,8 +18,8 @@ import static com.nowa.TemplateMod.MOD_ID;
 public class ModBlocks {
 
     public static final Block RUBY_BLOCK = registerBlock("ruby_block", new Block(FabricBlockSettings.copyOf(Blocks.EMERALD_BLOCK)));
-    public static final Block RUBY_ORE = registerBlock("ruby_ore", new ExperienceDroppingBlock(FabricBlockSettings.copyOf(Blocks.EMERALD_ORE)));
-    public static final Block DEEPSLATE_RUBY_ORE = registerBlock("deepslate_ruby_ore", new ExperienceDroppingBlock(FabricBlockSettings.copyOf(Blocks.DEEPSLATE_EMERALD_ORE)));
+    public static final Block RUBY_ORE = registerBlock("ruby_ore", new ExperienceDroppingBlock(FabricBlockSettings.copyOf(Blocks.EMERALD_ORE), UniformIntProvider.create(3, 7)));
+    public static final Block DEEPSLATE_RUBY_ORE = registerBlock("deepslate_ruby_ore", new ExperienceDroppingBlock(FabricBlockSettings.copyOf(Blocks.DEEPSLATE_EMERALD_ORE), UniformIntProvider.create(3, 7)));
 
     private static Block registerBlock(String name, Block block) {
         registerBlockItem(name, block);

--- a/src/main/java/com/nowa/block/ModBlocks.java
+++ b/src/main/java/com/nowa/block/ModBlocks.java
@@ -4,6 +4,7 @@ import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.ExperienceDroppingBlock;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
@@ -15,9 +16,9 @@ import static com.nowa.TemplateMod.MOD_ID;
 
 public class ModBlocks {
 
-    public static final Block RUBY_BLOCK = registerBlock("ruby_block", new Block(FabricBlockSettings.copyOf(Blocks.IRON_BLOCK)));
-    public static final Block RUBY_ORE = registerBlock("ruby_ore", new Block(FabricBlockSettings.copyOf(Blocks.RAW_IRON_BLOCK)));
-    public static final Block DEEPSLATE_RUBY_ORE = registerBlock("deepslate_ruby_ore", new Block(FabricBlockSettings.copyOf(Blocks.DEEPSLATE_IRON_ORE)));
+    public static final Block RUBY_BLOCK = registerBlock("ruby_block", new Block(FabricBlockSettings.copyOf(Blocks.EMERALD_BLOCK)));
+    public static final Block RUBY_ORE = registerBlock("ruby_ore", new ExperienceDroppingBlock(FabricBlockSettings.copyOf(Blocks.EMERALD_ORE)));
+    public static final Block DEEPSLATE_RUBY_ORE = registerBlock("deepslate_ruby_ore", new ExperienceDroppingBlock(FabricBlockSettings.copyOf(Blocks.DEEPSLATE_EMERALD_ORE)));
 
     private static Block registerBlock(String name, Block block) {
         registerBlockItem(name, block);

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/hoe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/hoe.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "template-mod:ruby_block",
+    "template-mod:ruby_ore",
+    "template-mod:deepslate_ruby_ore"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/shovel.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/shovel.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/needs_diamond_tool.json
+++ b/src/main/resources/data/minecraft/tags/blocks/needs_diamond_tool.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/needs_iron_tool.json
+++ b/src/main/resources/data/minecraft/tags/blocks/needs_iron_tool.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "template-mod:ruby_block",
+    "template-mod:ruby_ore",
+    "template-mod:deepslate_ruby_ore"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/needs_stone_tool.json
+++ b/src/main/resources/data/minecraft/tags/blocks/needs_stone_tool.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+
+  ]
+}

--- a/src/main/resources/data/template-mod/loot_tables/blocks/deepslate_ruby_ore.json
+++ b/src/main/resources/data/template-mod/loot_tables/blocks/deepslate_ruby_ore.json
@@ -1,0 +1,50 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "template-mod:deepslate_ruby_ore"
+            },
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:ore_drops",
+                  "function": "minecraft:apply_bonus"
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "template-mod:ruby"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "template-mod:blocks/deepslate_ruby_ore"
+}

--- a/src/main/resources/data/template-mod/loot_tables/blocks/ruby_block.json
+++ b/src/main/resources/data/template-mod/loot_tables/blocks/ruby_block.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "template-mod:ruby_block"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "template-mod:blocks/ruby_block"
+}

--- a/src/main/resources/data/template-mod/loot_tables/blocks/ruby_ore.json
+++ b/src/main/resources/data/template-mod/loot_tables/blocks/ruby_ore.json
@@ -1,0 +1,50 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "template-mod:ruby_ore"
+            },
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:ore_drops",
+                  "function": "minecraft:apply_bonus"
+                },
+                {
+                  "function": "minecraft:explosion_decay"
+                }
+              ],
+              "name": "template-mod:ruby"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "template-mod:blocks/ruby_ore"
+}


### PR DESCRIPTION
## 🧱 Context  
This PR add ruby blocks **loot tables** & **mineable rules** to the mod

## ✨ Changes

- ✅ Added `ruby_block` loot table & mineable rules
  - Can be mined with `iron_pickaxe` and higher level pickaxes
  - Loot `ruby_block` when mined

- ✅ Added `ruby_ore` loot table & mineable rules
  - Can be mined with `iron_pickaxe` and higher level pickaxes
  - Loot `ruby` when mined
  - Loot `ruby_ore` when mined with silk_touch enchanted pickaxe
  - Respect `fortune` enchantement rules

- ✅ Added `deepslate_ruby_ore` loot table & mineable rules
  - Can be mined with `iron_pickaxe` and higher level pickaxes
  - Loot `ruby` when mined
  - Loot `deepslate_ruby_ore` when mined with silk_touch enchanted pickaxe
  - Respect `fortune` enchantement rules

- 🔃 Update `ruby_ore` & `deepslate_ruby_ore` blocks to drop experience
  - Drops from `3` to `7` xp units (same as `emerald_ore` / `diamond_ore`)
